### PR TITLE
Add USB PID a69c:88de (AIC8800DC variant)

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -2036,7 +2036,7 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		usb_dev->chipid = PRODUCT_ID_AIC8801;
 		AICWFDBG(LOGINFO, "%s USE AIC8801\r\n", __func__);
 		return 0;
-	}else if(pid == USB_PRODUCT_ID_AIC8800DC){
+	}else if(pid == USB_PRODUCT_ID_AIC8800DC || pid == USB_PRODUCT_ID_AIC8800DE){
 		usb_dev->chipid = PRODUCT_ID_AIC8800DC;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);
 		return 0;
@@ -2318,6 +2318,7 @@ static struct usb_device_id aicwf_usb_id_table[] = {
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8801, 0xff, 0xff, 0xff)},
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800D81, 0xff, 0xff, 0xff)},
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DC, 0xff, 0xff, 0xff)},
+    {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DE, 0xff, 0xff, 0xff)},
     {USB_DEVICE(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DW)},
     {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC)},
     {USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA)},

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
@@ -24,6 +24,7 @@
 #else
 #define USB_PRODUCT_ID_AIC8801				0x8801
 #define USB_PRODUCT_ID_AIC8800DC			0x88dc
+#define USB_PRODUCT_ID_AIC8800DE			0x88de
 #define USB_PRODUCT_ID_AIC8800DW            0x88dd
 #define USB_PRODUCT_ID_AIC8800D81           0x8d81
 #define USB_PRODUCT_ID_AIC8800FC            0x88df


### PR DESCRIPTION
Some AIC8800DC-based USB Wi-Fi adapters enumerate with USB ID `a69c:88de`, which is not present in the driver's USB id table, so the driver fails to bind (the device stays unbound with interface class `ff/ff/ff`).

This adds product id `0x88de` and maps it to the existing AIC8800DC chip path:
- define `USB_PRODUCT_ID_AIC8800DE 0x88de`
- add it to `aicwf_usb_id_table`
- handle it in `aicwf_usb_chipmatch` as `PRODUCT_ID_AIC8800DC`

Tested on Ubuntu 26.04 / Linux 7.0.0 with a real `a69c:88de` adapter: the driver binds, `aic8800DC` firmware (`fmacfw_patch_8800dc_u02.bin`, chip_id=7/sub_id=1) loads, a managed `wlx*` interface is created, and scanning works.
