### PR TITLE
Support AIC8800DC variant a69c:88de and its 5722 storage-mode switch

### DIFF
--- a/aic.rules
+++ b/aic.rules
@@ -1,1 +1,2 @@
 KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5721",  SYMLINK+="aicudisk", RUN+="/usr/bin/eject /dev/%k"
+KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5722",  SYMLINK+="aicudisk", RUN+="/usr/bin/eject /dev/%k"


### PR DESCRIPTION
## Summary

Adds support for an AIC8800DC USB WiFi dongle variant that was not handled by the driver or the mode-switch udev rule.

This dongle ships in mass-storage (ZeroCD) mode as `a69c:5722` and switches to WiFi mode as `a69c:88de`. Two gaps prevented it from working:

1. **Mode switch missing** — `aic.rules` only ejected `a69c:5721`, so the `5722` variant stayed stuck as a USB drive and never re-enumerated into WiFi mode.
2. **Driver match missing** — the WiFi-mode PID `88de` was not in `aicwf_usb_id_table`, so `aic8800_fdrv` could not bind even after switching.

## Changes
- `aic.rules`: add eject rule for `a69c:5722`.
- `aicwf_usb.{c,h}`: add `USB_PRODUCT_ID_AIC8800DE (0x88de)` to the chip match logic and the USB id table.

## Testing
Verified on Linux (kernel 6.x, Ubuntu):
- Device enumerates as `a69c:5722` → udev ejects → re-enumerates as `a69c:88de`.
- `aic8800_fdrv` binds, `wlxXXXX` interface appears, `iw scan` returns nearby APs and the adapter connects normally.